### PR TITLE
fputils: add explicit padding to correctly align fp80_t

### DIFF
--- a/fpbits.h
+++ b/fpbits.h
@@ -84,6 +84,7 @@ build_fp64(int sign, uint64_t frac, int exp)
 
 #define BUILD_FP80(sign, frac, exp)                             \
     {                                                           \
+        .repr.pad = { 0 },                                      \
         .repr.se = BUILD_FP80_SE(sign, exp),                    \
         .repr.fi = BUILD_FP80_FI(frac, exp)                     \
     }

--- a/include/fputils/fptypes.h
+++ b/include/fputils/fptypes.h
@@ -69,12 +69,16 @@ typedef union  {
         uint64_t fi;
         /** Raw representation of sign bit and exponent */
         uint16_t se;
+        /** Add explicit padding to ensure this data structure
+         * is properly aligned.
+         */
+        uint16_t pad[3];
     } repr;
     /**
      * Represented as a char array, mainly intended for debug dumping
      * and serialization.
      */
-    char bits[10];
+    char bits[16];
 } fp80_t;
 
 /** @} */


### PR DESCRIPTION
the compiler seems to align the fp80_t data struct, so here we add
explicit padding to avoid confusion.